### PR TITLE
Fix FlowAddress and FlowId ByteArray size

### DIFF
--- a/src/main/kotlin/org/onflow/sdk/models.kt
+++ b/src/main/kotlin/org/onflow/sdk/models.kt
@@ -18,6 +18,9 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.time.LocalDateTime
 
+private const val FLOW_ID_SIZE_BYTES = 32
+private const val FLOW_ADDRESS_SIZE_BYTES = 8
+
 enum class FlowTransactionStatus(val num: Int) {
     UNKNOWN(0),
     PENDING(1),
@@ -750,9 +753,9 @@ interface BytesHolder {
 data class FlowAddress private constructor(override val bytes: ByteArray) : BytesHolder {
     companion object {
         @JvmStatic
-        fun of(bytes: ByteArray): FlowAddress = FlowAddress(fixedSize(bytes, 8))
+        fun of(bytes: ByteArray): FlowAddress = FlowAddress(fixedSize(bytes, FLOW_ADDRESS_SIZE_BYTES))
     }
-    constructor(hex: String) : this(hex.hexToBytes())
+    constructor(hex: String) : this(fixedSize(hex.hexToBytes(), FLOW_ADDRESS_SIZE_BYTES))
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -851,9 +854,9 @@ data class FlowSignature(override val bytes: ByteArray) : BytesHolder {
 data class FlowId private constructor(override val bytes: ByteArray) : BytesHolder {
     companion object {
         @JvmStatic
-        fun of(bytes: ByteArray): FlowId = FlowId(fixedSize(bytes, 32))
+        fun of(bytes: ByteArray): FlowId = FlowId(fixedSize(bytes, FLOW_ID_SIZE_BYTES))
     }
-    constructor(hex: String) : this(hex.hexToBytes())
+    constructor(hex: String) : this(fixedSize(hex.hexToBytes(), FLOW_ID_SIZE_BYTES))
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/src/test/kotlin/org/onflow/sdk/TransactionTest.kt
+++ b/src/test/kotlin/org/onflow/sdk/TransactionTest.kt
@@ -1,6 +1,7 @@
 package org.onflow.sdk
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.onflow.sdk.crypto.Crypto
 import org.onflow.sdk.test.FlowEmulatorTest
@@ -30,8 +31,8 @@ class TransactionTest {
         val pk3 = Crypto.getSigner(Crypto.generateKeyPair().private)
 
         val proposer = transaction.proposalKey.address
-        val authorizer = FlowAddress("012345678012345678")
-        val payer = FlowAddress("ababababababababab")
+        val authorizer = FlowAddress("0x18eb4ee6b3c026d3")
+        val payer = FlowAddress("0xd550da24ebb66d75")
 
         transaction = transaction.addPayloadSignature(proposer, 2, pk1)
         println("Authorization signature (proposer) ${transaction.payloadSignatures[0].signature.base16Value}")
@@ -337,5 +338,85 @@ class TransactionTest {
 
         assertThat(testTx.id.base16Value).isEqualTo(expectedTransactionIdAfterSigning)
         assertThat(testTx.canonicalTransaction.bytesToHex()).isEqualTo(expectedCanonicalTransactionHex)
+    }
+}
+
+class FlowIdTest {
+
+    @Test
+    fun `Can create FlowId from a hex string`() {
+        assertThat(FlowId("0x01").bytes).isEqualTo("0000000000000000000000000000000000000000000000000000000000000001".hexToBytes())
+        assertThat(FlowId("01").base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000001")
+        assertThat(FlowId("00").base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000000")
+        assertThat(FlowId("01").base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000001")
+        assertThat(FlowId("10").base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000010")
+        assertThat(FlowId("5e6ef76c524dd131bbab5f9965493b7830bb784561ca6391b320ec60fa5c395e").base16Value).isEqualTo("5e6ef76c524dd131bbab5f9965493b7830bb784561ca6391b320ec60fa5c395e")
+    }
+
+    @Test
+    fun `Can create FlowId from a byte array`() {
+        assertThat(FlowId.of("01".hexToBytes()).bytes).isEqualTo("0000000000000000000000000000000000000000000000000000000000000001".hexToBytes())
+        assertThat(FlowId.of("0x01".hexToBytes()).base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000001")
+        assertThat(FlowId.of(byteArrayOf()).base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000000")
+        assertThat(FlowId.of("01".hexToBytes()).base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000001")
+        assertThat(FlowId.of("10".hexToBytes()).base16Value).isEqualTo("0000000000000000000000000000000000000000000000000000000000000010")
+        assertThat(FlowId.of("5e6ef76c524dd131bbab5f9965493b7830bb784561ca6391b320ec60fa5c395e".hexToBytes()).base16Value).isEqualTo("5e6ef76c524dd131bbab5f9965493b7830bb784561ca6391b320ec60fa5c395e")
+    }
+
+    @Test
+    fun `Throws error creating FlowId from invalid input`() {
+        assertThatThrownBy { FlowId.of("0x1".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowId.of("x".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowId.of("1".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowId.of("0k".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowId.of("0".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowId.of("0000000000000000000000000000000000000000000000000000000000000001234".hexToBytes()).bytes }
+        assertThatThrownBy { FlowId("0x1").base16Value }
+        assertThatThrownBy { FlowId("x").base16Value }
+        assertThatThrownBy { FlowId("1").base16Value }
+        assertThatThrownBy { FlowId("0").base16Value }
+        assertThatThrownBy { FlowId("0000000000000000000000000000000000000000000000000000000000000001234").bytes }
+    }
+}
+
+class FlowAddressTest {
+
+    @Test
+    fun `Can create FlowAddress from a hex string`() {
+        assertThat(FlowAddress("0x01").base16Value).isEqualTo("0000000000000001")
+        assertThat(FlowAddress("01").bytes).isEqualTo("0000000000000001".hexToBytes())
+        assertThat(FlowAddress("00").base16Value).isEqualTo("0000000000000000")
+        assertThat(FlowAddress("01").base16Value).isEqualTo("0000000000000001")
+        assertThat(FlowAddress("10").base16Value).isEqualTo("0000000000000010")
+        assertThat(FlowAddress("0x18eb4ee6b3c026d3").base16Value).isEqualTo("18eb4ee6b3c026d3")
+        assertThat(FlowAddress("0x18eb4ee6b3c026d3").formatted).isEqualTo("0x18eb4ee6b3c026d3")
+        assertThat(FlowAddress("18eb4ee6b3c026d3").formatted).isEqualTo("0x18eb4ee6b3c026d3")
+    }
+
+    @Test
+    fun `Can create FlowAddress from a byte array`() {
+        assertThat(FlowAddress.of("0x01".hexToBytes()).base16Value).isEqualTo("0000000000000001")
+        assertThat(FlowAddress.of("01".hexToBytes()).bytes).isEqualTo("0000000000000001".hexToBytes())
+        assertThat(FlowAddress.of("00".hexToBytes()).base16Value).isEqualTo("0000000000000000")
+        assertThat(FlowAddress.of("01".hexToBytes()).base16Value).isEqualTo("0000000000000001")
+        assertThat(FlowAddress.of("10".hexToBytes()).base16Value).isEqualTo("0000000000000010")
+        assertThat(FlowAddress.of("0x18eb4ee6b3c026d3".hexToBytes()).base16Value).isEqualTo("18eb4ee6b3c026d3")
+        assertThat(FlowAddress.of("0x18eb4ee6b3c026d3".hexToBytes()).formatted).isEqualTo("0x18eb4ee6b3c026d3")
+        assertThat(FlowAddress.of("18eb4ee6b3c026d3".hexToBytes()).formatted).isEqualTo("0x18eb4ee6b3c026d3")
+    }
+
+    @Test
+    fun `Throws error creating FlowAddress from invalid input`() {
+        assertThatThrownBy { FlowAddress.of("0x1".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowAddress.of("x".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowAddress.of("0k".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowAddress.of("1".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowAddress.of("0".hexToBytes()).base16Value }
+        assertThatThrownBy { FlowAddress.of("18eb4ee6b3c026d31".hexToBytes()).bytes }
+        assertThatThrownBy { FlowAddress("0x1").base16Value }
+        assertThatThrownBy { FlowAddress("x").base16Value }
+        assertThatThrownBy { FlowAddress("1").base16Value }
+        assertThatThrownBy { FlowAddress("0").base16Value }
+        assertThatThrownBy { FlowAddress("18eb4ee6b3c026d31").bytes }
     }
 }


### PR DESCRIPTION
## Description

This PR pads the bytes of the `FlowId` and `FlowAddress` classes when an instance is created using the constructor methods (similar to the `of(bytes: ByteArray)` implementation).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
