### PR TITLE
Add option to set the gRPC maxInboundMessageSize

### DIFF
--- a/src/main/kotlin/com/nftco/flow/sdk/Flow.kt
+++ b/src/main/kotlin/com/nftco/flow/sdk/Flow.kt
@@ -62,7 +62,7 @@ object Flow {
         var channelBuilder = ManagedChannelBuilder
             .forAddress(host, port)
             .userAgent(userAgent)
-            .maxInboundMessageSize(maxMessageSize);
+            .maxInboundMessageSize(maxMessageSize)
 
         channelBuilder = if (secure) {
             channelBuilder.useTransportSecurity()

--- a/src/main/kotlin/com/nftco/flow/sdk/Flow.kt
+++ b/src/main/kotlin/com/nftco/flow/sdk/Flow.kt
@@ -17,7 +17,7 @@ object Flow {
 
     const val DEFAULT_USER_AGENT = "Flow JVM SDK"
 
-    const val DEFAULT_MAX_MESSAGE_SIZE = 20971520
+    const val DEFAULT_MAX_MESSAGE_SIZE = 16777216
 
     var OBJECT_MAPPER: ObjectMapper
 

--- a/src/main/kotlin/com/nftco/flow/sdk/Flow.kt
+++ b/src/main/kotlin/com/nftco/flow/sdk/Flow.kt
@@ -17,6 +17,8 @@ object Flow {
 
     const val DEFAULT_USER_AGENT = "Flow JVM SDK"
 
+    const val DEFAULT_MAX_MESSAGE_SIZE = 20971520
+
     var OBJECT_MAPPER: ObjectMapper
 
     var DEFAULT_CHAIN_ID: FlowChainId = FlowChainId.MAINNET
@@ -43,23 +45,24 @@ object Flow {
 
     @JvmStatic
     @JvmOverloads
-    fun newAccessApi(host: String, port: Int = 9000, secure: Boolean = false, userAgent: String = DEFAULT_USER_AGENT): FlowAccessApi {
-        val channel = openChannel(host, port, secure, userAgent)
+    fun newAccessApi(host: String, port: Int = 9000, secure: Boolean = false, userAgent: String = DEFAULT_USER_AGENT, maxMessageSize: Int = DEFAULT_MAX_MESSAGE_SIZE): FlowAccessApi {
+        val channel = openChannel(host, port, secure, userAgent, maxMessageSize)
         return FlowAccessApiImpl(AccessAPIGrpc.newBlockingStub(channel))
     }
 
     @JvmStatic
     @JvmOverloads
-    fun newAsyncAccessApi(host: String, port: Int = 9000, secure: Boolean = false, userAgent: String = DEFAULT_USER_AGENT): AsyncFlowAccessApi {
-        val channel = openChannel(host, port, secure, userAgent)
+    fun newAsyncAccessApi(host: String, port: Int = 9000, secure: Boolean = false, userAgent: String = DEFAULT_USER_AGENT, maxMessageSize: Int = DEFAULT_MAX_MESSAGE_SIZE): AsyncFlowAccessApi {
+        val channel = openChannel(host, port, secure, userAgent, maxMessageSize)
         return AsyncFlowAccessApiImpl(AccessAPIGrpc.newFutureStub(channel))
     }
 
     @JvmStatic
-    private fun openChannel(host: String, port: Int, secure: Boolean, userAgent: String): ManagedChannel {
+    private fun openChannel(host: String, port: Int, secure: Boolean, userAgent: String, maxMessageSize: Int): ManagedChannel {
         var channelBuilder = ManagedChannelBuilder
             .forAddress(host, port)
             .userAgent(userAgent)
+            .maxInboundMessageSize(maxMessageSize);
 
         channelBuilder = if (secure) {
             channelBuilder.useTransportSecurity()


### PR DESCRIPTION
Closes: #6 

## Description
- Allow setting the `maxInboundMessageSize` gRPC channel property
- Increase the default `maxInboundMessageSize` to 16MB (matching the flow access node default [value](https://github.com/onflow/flow-go/blob/11299bb49b98d8f5c45ba5748c22744e53e36a80/utils/grpcutils/grpc.go#L18))


______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
