### PR TITLE
Fix android signature incorrect issue

### DIFF
--- a/src/main/kotlin/com/nftco/flow/sdk/models.kt
+++ b/src/main/kotlin/com/nftco/flow/sdk/models.kt
@@ -312,15 +312,15 @@ data class FlowTransactionResult(
 }
 
 internal class Payload(
-    val script: ByteArray,
-    val arguments: List<ByteArray>,
-    val referenceBlockId: ByteArray,
-    val gasLimit: Long,
-    val proposalKeyAddress: ByteArray,
-    val proposalKeyIndex: Long,
-    val proposalKeySequenceNumber: Long,
-    val payer: ByteArray,
-    val authorizers: List<ByteArray>
+    @RLP(0) val script: ByteArray,
+    @RLP(1) val arguments: List<ByteArray>,
+    @RLP(2) val referenceBlockId: ByteArray,
+    @RLP(3) val gasLimit: Long,
+    @RLP(4) val proposalKeyAddress: ByteArray,
+    @RLP(5) val proposalKeyIndex: Long,
+    @RLP(6) val proposalKeySequenceNumber: Long,
+    @RLP(7) val payer: ByteArray,
+    @RLP(8) val authorizers: List<ByteArray>
 ) {
     // no-arg constructor required for decoding
     constructor() : this(byteArrayOf(), listOf(), byteArrayOf(), 0, byteArrayOf(), 0, 0, byteArrayOf(), listOf())
@@ -343,9 +343,9 @@ internal class TransactionEnvelope(
 )
 
 internal class EnvelopeSignature(
-    val signerIndex: Int,
-    val keyIndex: Int,
-    val signature: ByteArray
+    @RLP(0) val signerIndex: Int,
+    @RLP(1) val keyIndex: Int,
+    @RLP(2) val signature: ByteArray
 ) {
     // no-arg constructor required for decoding
     constructor() : this(0, 0, byteArrayOf())


### PR DESCRIPTION
Closes: #5, #8, #11

## Description

Hi,

I'm the maintainer of [flow-swift](https://github.com/outblock/flow-swift) SDK. 
While I using this library in android, it always got some signature error.
When I dig deeper into the issue, I found the issue might relate to the incorrect order of RLP encoding.
Once I added the RLP annotation in order, it works fine.

Here is a quick example:
```
// Flow Swift ✅
[
  [
    "0x7472616e73616374696f6e207b0a202065786563757465207b0a202020206c6f67282241207472616e73616374696f6e2068617070656e656422290a20207d0a7d",
    [],
    "0x2e1c36286ee035ad70a605635a4ebb98a342fc0c95bb03fea031a10ff542c7c1",
    "0x03e8",
    "0x4f05d22690e07938",
    "0x01",
    "0x09",
    "0x4f05d22690e07938",
    []
  ],
  []
]


// Flow JVM ❌
[
    [
      [],
      [],
      "0x03e8",
      "0x4f05d22690e07938",
      "0x4f05d22690e07938",
      "0x01",
      "0x09",
      "0x2e1c36286ee035ad70a605635a4ebb98a342fc0c95bb03fea031a10ff542c7c1",
      "0x7472616e73616374696f6e207b0a202065786563757465207b0a20202020206c6f67282241207472616e73616374696f6e2068617070656e656422290a20207d0a7d"
    ],
    []
  ]
  
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
