### PR TITLE
fixed registration of the contract during testing

### DIFF
--- a/src/main/kotlin/com/nftco/flow/sdk/AddressRegistry.kt
+++ b/src/main/kotlin/com/nftco/flow/sdk/AddressRegistry.kt
@@ -43,6 +43,7 @@ class AddressRegistry {
 
     @JvmOverloads
     fun register(contract: String, address: FlowAddress, chainId: FlowChainId = defaultChainId): AddressRegistry {
+        assert(contract.startsWith("0x")) { "Import alias must start with '0x' prefix, but found `$contract`" }
         SCRIPT_TOKEN_MAP.computeIfAbsent(chainId) { mutableMapOf() }[contract] = address
         return this
     }

--- a/src/test/kotlin/com/nftco/flow/sdk/TestExtensionsTest.kt
+++ b/src/test/kotlin/com/nftco/flow/sdk/TestExtensionsTest.kt
@@ -80,6 +80,25 @@ class TestExtensionsTest {
     @FlowTestAccount
     lateinit var account4: TestAccount
 
+    @FlowTestAccount(
+        signAlgo = SignatureAlgorithm.ECDSA_SECP256k1,
+        balance = 420.0,
+        contracts = [
+            FlowTestContractDeployment(
+                name = "ContractInterface",
+                code = "pub contract interface ContractInterface { }"
+            ),
+            FlowTestContractDeployment(
+                name = "ContractSuccessor",
+                code = """
+                    import ContractInterface from 0xCONTRACTINTERFACE
+                    pub contract ContractSuccessor : ContractInterface { init() { } }
+                """
+            ),
+        ]
+    )
+    lateinit var account5: TestAccount
+
     @Test
     fun `Test extensions work`() {
         accessAPI.ping()
@@ -90,14 +109,16 @@ class TestExtensionsTest {
         assertTrue(account2.isValid)
         assertTrue(account3.isValid)
         assertTrue(account4.isValid)
+        assertTrue(account5.isValid)
 
         val addresses = setOf(
             account0.flowAddress,
             account1.flowAddress,
             account2.flowAddress,
             account3.flowAddress,
-            account4.flowAddress
+            account4.flowAddress,
+            account5.flowAddress,
         )
-        assertEquals(5, addresses.size)
+        assertEquals(6, addresses.size)
     }
 }

--- a/src/testFixtures/kotlin/com/nftco/flow/sdk/test/AbstractFlowEmulatorExtension.kt
+++ b/src/testFixtures/kotlin/com/nftco/flow/sdk/test/AbstractFlowEmulatorExtension.kt
@@ -67,6 +67,7 @@ annotation class FlowTestAccount(
 @API(status = API.Status.STABLE, since = "5.0")
 annotation class FlowTestContractDeployment(
     val name: String,
+    val alias: String = "",
     val addToRegistry: Boolean = true,
     val code: String = "",
     val codeClasspathLocation: String = "",
@@ -158,6 +159,7 @@ abstract class AbstractFlowEmulatorExtension : BeforeEachCallback, AfterEachCall
     override fun beforeEach(context: ExtensionContext) {
 
         Flow.configureDefaults(chainId = FlowChainId.EMULATOR)
+        Flow.DEFAULT_ADDRESS_REGISTRY.defaultChainId = FlowChainId.EMULATOR
 
         val emulator = launchEmulator(context)
         this.process = emulator.process
@@ -262,7 +264,8 @@ abstract class AbstractFlowEmulatorExtension : BeforeEachCallback, AfterEachCall
                     .throwOnError()
 
                 if (deployable.addToRegistry) {
-                    Flow.DEFAULT_ADDRESS_REGISTRY.register(deployable.name, testAccount.flowAddress, FlowChainId.EMULATOR)
+                    val alias = deployable.alias.ifEmpty { "0x${deployable.name.uppercase()}" }
+                    Flow.DEFAULT_ADDRESS_REGISTRY.register(alias, testAccount.flowAddress, FlowChainId.EMULATOR)
                 }
             }
         }


### PR DESCRIPTION
Closes: #13 

* added FlowTestContractDeployment::alias (default "0x{name.uppercase()}")
* checking prefix '0x' when registering an address
* set AddressRegistry::defaultChainId to EMULATOR when configuring