### PR TITLE
remove zeros from private key that cause bad stuff

### DIFF
--- a/src/testFixtures/kotlin/com/nftco/flow/sdk/test/FlowEmulatorTestExtension.kt
+++ b/src/testFixtures/kotlin/com/nftco/flow/sdk/test/FlowEmulatorTestExtension.kt
@@ -59,8 +59,7 @@ class FlowEmulatorTestExtension : AbstractFlowEmulatorExtension() {
 
         val args = """
             --verbose --grpc-debug 
-            --service-priv-key=${serviceKeyPair.private.hex}
-            --service-pub-key=${serviceKeyPair.public.hex}
+            --service-priv-key=${serviceKeyPair.private.hex.replace(Regex("^(00)+"), "")}
             --service-sig-algo=${config.signAlgo.name.uppercase()}
             --service-hash-algo=${config.hashAlgo.name.uppercase()}
         """.trimIndent()


### PR DESCRIPTION
Closes: #???

## Description

removes leading pairs of zeros on private key generation that was causing flaky tests.
also removed the public key since it's no longer needed.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-jvm-sdk/blob/master/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
